### PR TITLE
Add in log the elapsed time for each task and global

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -30,6 +30,7 @@ use std::io::{self, Write};
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use chrono::Local;
 
 use std::{sync::mpsc, thread, time::Duration};
 #[cfg(target_os = "windows")]
@@ -57,6 +58,7 @@ use linux_imports::*;
 
 #[cfg(target_os = "windows")]
 pub fn run_internal(tool_name: &str, output_filename: &str) -> Option<String> {
+    let internal_starttime = Local::now();
     dprintln!("[INFO] > `{}` | Starting execution", tool_name);
 
     let output_file_path = Path::new(output_filename);
@@ -80,13 +82,20 @@ pub fn run_internal(tool_name: &str, output_filename: &str) -> Option<String> {
         tool_name,
         output_filename
     );
-    dprintln!("[INFO] > `{}` | Execution completed", tool_name);
+    let internal_elapsed = Local::now() - internal_starttime;
+    dprintln!(
+		"[INFO] > `{}` | Execution completed in {:?}.{:?} sec", 
+        tool_name,
+        internal_elapsed.num_seconds(),
+        internal_elapsed.num_milliseconds()-internal_elapsed.num_seconds(),
+    );
 
     return output;
 }
 
 #[cfg(target_os = "linux")]
 pub fn run_internal(tool_name: &str, output_filename: &str) -> Option<String> {
+    let internal_starttime = Local::now();
     dprintln!("[INFO] > `{}` | Starting execution", tool_name);
 
     let output_file_path = Path::new(output_filename);
@@ -108,7 +117,13 @@ pub fn run_internal(tool_name: &str, output_filename: &str) -> Option<String> {
         tool_name,
         output_filename
     );
-    dprintln!("[INFO] > `{}` | Execution completed", tool_name);
+    let internal_elapsed = Local::now() - internal_starttime;
+    dprintln!(
+		"[INFO] > `{}` | Execution completed in {:?}.{:?} sec", 
+        tool_name,
+        internal_elapsed.num_seconds(),
+        internal_elapsed.num_milliseconds()-internal_elapsed.num_seconds(),
+    );
 
     return output;
 }
@@ -123,6 +138,7 @@ pub fn run(
     memory_limit: Option<usize>,
     timeout: Option<u64>,
 ) -> Option<String> {
+    let task_starttime = Local::now();
     let mut display_name = name.clone();
     if exec_type == ExecType::External {
         let buffer = match exe_bytes {
@@ -227,7 +243,7 @@ pub fn run(
                 Ok(None) => {
                     if rx.try_recv().is_ok() {
                         dprintln!(
-                            "[WARN] > `{}` (pid: {}) | Execution timed out",
+                            "[WARN] > `{}` ({}) | Execution timed out",
                             display_name,
                             pid
                         );
@@ -276,10 +292,13 @@ pub fn run(
         pid,
         output_file
     );
+    let task_elapsed = Local::now() - task_starttime;
     dprintln!(
-        "[INFO] > `{}` ({}) | Execution completed",
+        "[INFO] > `{}` ({}) | Execution completed in {:?}.{:?} sec",
         display_name,
-        pid
+        pid,
+        task_elapsed.num_seconds(),
+        task_elapsed.num_milliseconds()-task_elapsed.num_seconds(), 
     );
 
     return Some(output_content);

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ use zip::DateTime as ZipDateTime;
 use chrono::Datelike;
 use chrono::Timelike;
 use resource_check::check_memory;
+use chrono::Local;
 
 #[cfg(target_os = "windows")]
 pub mod resource;
@@ -460,6 +461,7 @@ fn main() -> Result<(), anyhow::Error> {
     println!("Developed by: {}", env!("CARGO_PKG_AUTHORS"));
     println!();
 
+    let globalstarttime = Local::now();
     dprintln!("Aralez version: {} ({})", env!("CARGO_PKG_VERSION"), TARGET_ARCH);
     dprintln!("Configuration version: {} ", &config.version.clone().unwrap_or("unknown".to_string()));
 
@@ -717,7 +719,8 @@ fn main() -> Result<(), anyhow::Error> {
         }
     }
 
-    dprintln!("[INFO] All tasks completed");
+    let globalelapsed = Local::now() - globalstarttime;
+    dprintln!("[INFO] All tasks completed in around {:?} sec", globalelapsed.num_seconds());
 
     let src_log_file = format!("{}.log", root_output);
     // Move the logfile into the root folder


### PR DESCRIPTION
Please check if you agree with location of "starttime" evaluation both for task and global because it will change the value of elapsed time. Moreover in case of timeout the "elapsed time" is still showed and usally greater because include some additional activities in the code.